### PR TITLE
Took off animation for off topic

### DIFF
--- a/ui/js/conversationResponse.js
+++ b/ui/js/conversationResponse.js
@@ -80,15 +80,6 @@ var ConversationResponse = (function() {
         option: function(choice) { Panel.mapNavigation(choice); },
         cuisine: function() { Panel.mapFoodNumbers(); },
         func: function() { Panel.mapGeneral(); }
-      },
-      off_topic: {
-        amenity: {
-          gas: function() { Panel.mapGas(); },
-          restaurant: function() { Panel.mapFoodCuisine(); },
-          restroom: function() { Panel.mapRestrooms(); }
-        },
-        cuisine: function() { Panel.mapFoodNumbers(); },
-        genre: function(value) { Panel.playMusic(value); }
       }
     };
   }


### PR DESCRIPTION
When the user says "classical" or "burgers," Watson responds with an off-topic response and now no longer shows any animation along with this.
