### PR TITLE
Allows user to instantly input speech if mic is clicked

### DIFF
--- a/ui/ibm/speech-to-text.js
+++ b/ui/ibm/speech-to-text.js
@@ -43,11 +43,11 @@ var STTModule = (function() {
 
   function micON() { // When the microphone button is clicked
     if (recording === false) {
-      if (records === 0) {
+      if (records === 0) { // The first time the mic is clicked - inform user
         Api.setWatsonPayload({output: {text: ['Accept the microphone prompt in your browser. Watson will listen soon.'], ref: 'STT'}}); // Dialog box output to let the user know we're recording
         records++;
       } else {
-        Api.setWatsonPayload({output: {text: ['Listening soon!'], ref: 'STT'}}); // Dialog box output to let the user know we're recording
+        Api.setWatsonPayload({output: {ref: 'STT'}}); // Let the user record right away
       }
     } else {
       recording = false;

--- a/ui/ibm/text-to-speech.js
+++ b/ui/ibm/text-to-speech.js
@@ -69,30 +69,37 @@ var TTSModule = (function() {
         return response.text();
       }).then(function(token) {
         if (button.value === 'ON') {
-          // Pauses the audio for older message if there is a more current message
-          if (audio !== null && !audio.ended) {
-            audio.pause();
-          }
-
           // Takes text, voice, and token and returns speech
-          audio = WatsonSpeech.TextToSpeech.synthesize({
-            text: payload.text, // Output text/response
-            voice: 'en-US_MichaelVoice', // Default Watson voice
-            autoPlay: true, // Automatically plays audio
-            token: token
-          });
-
-          // When the audio stops playing
-          audio.onended = function() {
-            allowSTT(payload);
-          };
-        } else {
-          allowSTT(payload);
+          if (payload.text) { // If payload.text is defined
+            // Pauses the audio for older message if there is a more current message
+            if (audio !== null && !audio.ended) {
+              audio.pause();
+            }
+            audio = WatsonSpeech.TextToSpeech.synthesize({
+              text: payload.text, // Output text/response
+              voice: 'en-US_MichaelVoice', // Default Watson voice
+              autoPlay: true, // Automatically plays audio
+              token: token
+            });
+            // When the audio stops playing
+            audio.onended = function() {
+              allowSTT(payload); // Check if user wants to use STT
+            };
+          } else {
+            // Pauses the audio for older message if there is a more current message
+            if (audio !== null && !audio.ended) {
+              audio.pause();
+            }
+            // When payload.text is undefined
+            allowSTT(payload); // Check if user wants to use STT
+          }
+        } else { // When TTS is muted
+          allowSTT(payload); // Check if user wants to use STT
         }
       });
   }
 
-  // Check ref for 'STT' and allow STT
+  // Check ref for 'STT' and allow user to use STT
   function allowSTT(payload) {
     if (payload.ref === 'STT') {
       STTModule.speechToText();


### PR DESCRIPTION
The first time user clicks the mic, Watson will prompt the user, "Accept the microphone prompt in your browser. Watson will listen soon." After this, there will be no more responses from Watson when the mic is clicked.  If the user clicks the mic again, he or she will be able to input speech instantly, rather than waiting for another response from Watson to finish. The user can input speech when the mic button is green.
